### PR TITLE
tiny_snippet - Custom Patch by Stan Muravyev @EHL

### DIFF
--- a/classes/plugininfo.php
+++ b/classes/plugininfo.php
@@ -137,8 +137,9 @@ class plugininfo extends plugin implements plugin_with_configuration, plugin_wit
                 if(strpos($default,'|')) {
                     $default = explode('|', $default);
                     $isarray=true;
-                } else if (strpos($default, '#')) {
+                } else if (strpos($default, '##longtext')) {
                     $islongtext = true;
+                    $default = str_replace('##longtext', '', $default);
                 }
                 $display_name = str_replace('_',' ',$var);
                 $display_name = str_replace('-',' ',$display_name);

--- a/classes/plugininfo.php
+++ b/classes/plugininfo.php
@@ -133,14 +133,22 @@ class plugininfo extends plugin implements plugin_with_configuration, plugin_wit
             foreach($allvariables as $var){
                 $default = isset($alldefaults[$var]) ? $alldefaults[$var] : '';
                 $isarray=false;
+                $islongtext = false;
                 if(strpos($default,'|')) {
                     $default = explode('|', $default);
                     $isarray=true;
+                } else if (strpos($default, '#')) {
+                    $islongtext = true;
                 }
                 $display_name = str_replace('_',' ',$var);
                 $display_name = str_replace('-',' ',$display_name);
                 $display_name =ucwords($display_name);
-                $widget->variables[] = ['key'=>$var,'default'=>$default, 'isarray'=>$isarray, 'displayname'=>$display_name];
+                $widget->variables[] = [
+                    'key'=>$var,
+                    'default'=>$default,
+                    'isarray'=>$isarray,
+                    'islongtext'=>$islongtext,
+                    'displayname'=>$display_name];
             }
 
             //set the template index so we can find it easily later.

--- a/classes/plugininfo.php
+++ b/classes/plugininfo.php
@@ -137,9 +137,9 @@ class plugininfo extends plugin implements plugin_with_configuration, plugin_wit
                 if(strpos($default,'|')) {
                     $default = explode('|', $default);
                     $isarray=true;
-                } else if (strpos($default, '##longtext')) {
+                } else if (isset($default[0]) && $default[0] === "#") {
                     $islongtext = true;
-                    $default = str_replace('##longtext', '', $default);
+                    $default = substr($default, 1);
                 }
                 $display_name = str_replace('_',' ',$var);
                 $display_name = str_replace('-',' ',$display_name);

--- a/styles.css
+++ b/styles.css
@@ -12,6 +12,12 @@
     float:right;
 }
 
+.tiny_snippet_form {
+    width: 80%;
+    max-width: 600px;
+    margin: 0 auto;
+}
+
 div.tiny_snippet_dragging {
     border:2px dashed #0000FF;
 }
@@ -32,8 +38,10 @@ div.tiny_snippet_widget_buttons {
 }
 
 .tiny_snippet_widgetoptionsbuttons_cont{
-    margin: 10px;
-    margin-left: 100px;
+    display: flex;
+    justify-content: flex-start;
+    gap: 10px;
+    margin-top: 20px;
 }
 
 .tiny_snippet_widgetoptionlabel {
@@ -49,4 +57,12 @@ div.tiny_snippet_widget_buttons {
     display: flex;
     align-items: flex-start;
     margin-bottom: 1rem;
+    margin-right: 1rem;
+}
+
+/* Test - might remove */
+input,
+select,
+textarea {
+    padding: 5px;
 }

--- a/styles.css
+++ b/styles.css
@@ -16,14 +16,17 @@ div.tiny_snippet_dragging {
     border:2px dashed #0000FF;
 }
 
-
 .tiny_snippet_field{
-    width: 200px;
+    flex: 1;
+    min-width: 200px;
+    max-width: 100%;
 }
+
 div.tiny_snippet_widget_buttons {
     display: inline-block;
     margin: 5px;
 }
+
 .tiny_snippet_hidden{
     display: none;
 }
@@ -32,7 +35,18 @@ div.tiny_snippet_widget_buttons {
     margin: 10px;
     margin-left: 100px;
 }
+
 .tiny_snippet_widgetoptionlabel {
-    padding: 10px;
-    width: 200px;
+    width: 30%;
+    min-width: 180px;
+    padding-right: 1em;
+    font-weight: bold;
+    word-break: break-word;
+    white-space: normal;
+}
+
+.tiny_snippet_form_row {
+    display: flex;
+    align-items: flex-start;
+    margin-bottom: 1rem;
 }

--- a/styles.css
+++ b/styles.css
@@ -18,6 +18,18 @@
     margin: 0 auto;
 }
 
+.tiny_snippet_widget_instructions {
+    text-align: left;
+    padding: 0 20px 10px 20px;
+    margin: 0;
+}
+
+.tiny_snippet_widget_instructions_title {
+    text-align: left;
+    padding: 0 20px;
+    margin-bottom: 5px;
+}
+
 div.tiny_snippet_dragging {
     border:2px dashed #0000FF;
 }
@@ -66,3 +78,4 @@ select,
 textarea {
     padding: 5px;
 }
+

--- a/styles.css
+++ b/styles.css
@@ -34,5 +34,5 @@ div.tiny_snippet_widget_buttons {
 }
 .tiny_snippet_widgetoptionlabel {
     padding: 10px;
-    width: 100px;
+    width: 200px;
 }

--- a/templates/widgetoptions.mustache
+++ b/templates/widgetoptions.mustache
@@ -16,7 +16,14 @@
                     </select>
             {{/isarray}}
             {{^isarray}}
-                <input type="text" data-key="{{key}}" name="{{key}}" id="{{key}}" class="tiny_snippet_templatevariable_{{templateindex}} tiny_snippet_widget_field" value="{{default}}"></input>
+                {{#islongtext}}
+                    <textarea data-key="{{key}}" name="{{key}}" id="{{key}}" class="tiny_snippet_templatevariable_{{templateindex}} tiny_snippet_widget_field"
+                    rows="5" cols="40">{{default}}</textarea>
+                {{/islongtext}}
+
+                {{^islongtext}}
+                    <input type="text" data-key="{{key}}" name="{{key}}" id="{{key}}" class="tiny_snippet_templatevariable_{{templateindex}} tiny_snippet_widget_field" value="{{default}}"></input>
+                {{/islongtext}}
             {{/isarray}}
         </div>
         {{/variables}}

--- a/templates/widgetoptions.mustache
+++ b/templates/widgetoptions.mustache
@@ -7,25 +7,26 @@
 <form class="tiny_snippet_form" id="{{uniqid}}_tiny_snippet_form">
     <div class="root tab-content">
         {{#variables}}
-        <div><label for="{{key}}" class="tiny_snippet_widgetoptionlabel">{{displayname}}</label>
-            {{#isarray}}
-                    <select data-key="{{key}}" name="{{key}}" id="{{key}}" class="tiny_snippet_templatevariable_{{templateindex}} tiny_snippet_widget_field">
-                        {{#default}}
-                        <option value="{{.}}">{{.}}</option>
-                        {{/default}}
-                    </select>
-            {{/isarray}}
-            {{^isarray}}
-                {{#islongtext}}
-                    <textarea data-key="{{key}}" name="{{key}}" id="{{key}}" class="tiny_snippet_templatevariable_{{templateindex}} tiny_snippet_widget_field"
-                    rows="5" cols="40">{{default}}</textarea>
-                {{/islongtext}}
+            <div class="tiny_snippet_form_row">
+                <label for="{{key}}" class="tiny_snippet_widgetoptionlabel">{{displayname}}</label>
+                    {{#isarray}}
+                        <select data-key="{{key}}" name="{{key}}" id="{{key}}" class="tiny_snippet_templatevariable_{{templateindex}} tiny_snippet_widget_field">
+                            {{#default}}
+                                <option value="{{.}}">{{.}}</option>
+                            {{/default}}
+                        </select>
+                    {{/isarray}}
+                    {{^isarray}}
+                        {{#islongtext}}
+                            <textarea data-key="{{key}}" name="{{key}}" id="{{key}}" class="tiny_snippet_templatevariable_{{templateindex}} tiny_snippet_widget_field"
+                            rows="5" cols="40">{{default}}</textarea>
+                        {{/islongtext}}
 
-                {{^islongtext}}
-                    <input type="text" data-key="{{key}}" name="{{key}}" id="{{key}}" class="tiny_snippet_templatevariable_{{templateindex}} tiny_snippet_widget_field" value="{{default}}"></input>
-                {{/islongtext}}
-            {{/isarray}}
-        </div>
+                        {{^islongtext}}
+                            <input type="text" data-key="{{key}}" name="{{key}}" id="{{key}}" class="tiny_snippet_templatevariable_{{templateindex}} tiny_snippet_widget_field" value="{{default}}"></input>
+                        {{/islongtext}}
+                    {{/isarray}}
+            </div>
         {{/variables}}
     </div>
     <div class="tiny_snippet_widgetoptionsbuttons_cont">

--- a/templates/widgetoptions.mustache
+++ b/templates/widgetoptions.mustache
@@ -1,6 +1,6 @@
 
 <div id="{{elementid}}_{{innerform}}" class="mdl-align">
-<h4 class="tiny_snippet_widget_instructions">{{name}}</h4>
+<h4 class="tiny_snippet_widget_instructions_title">{{name}}</h4>
 <div class="tiny_snippet_widget_instructions">{{instructions}}</div>
 </div>
 

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'tiny_snippet';
-$plugin->release = '1.0.2 (Build 2025041702)';
+$plugin->release = '1.0.2 (Build 2025041703)';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->requires = 2022112800;//Moodle 4.1.0
-$plugin->version = 2025041702;
+$plugin->version = 2025041703;

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'tiny_snippet';
-$plugin->release = '1.0.2 (Build 2025041703)';
+$plugin->release = '1.0.2 (Build 2025041704)';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->requires = 2022112800;//Moodle 4.1.0
-$plugin->version = 2025041703;
+$plugin->version = 2025041704;

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'tiny_snippet';
-$plugin->release = '1.0.2 (Build 2025041704)';
+$plugin->release = '1.0.2 (Build 2025041705)';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->requires = 2022112800;//Moodle 4.1.0
-$plugin->version = 2025041704;
+$plugin->version = 2025041705;

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'tiny_snippet';
-$plugin->release = '1.0.2 (Build 2025041701)';
+$plugin->release = '1.0.2 (Build 2025041702)';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->requires = 2022112800;//Moodle 4.1.0
-$plugin->version = 2025041701;
+$plugin->version = 2025041702;

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'tiny_snippet';
-$plugin->release = '1.0.2 (Build 2025041700)';
+$plugin->release = '1.0.2 (Build 2025041701)';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->requires = 2022112800;//Moodle 4.1.0
-$plugin->version = 2025041700;
+$plugin->version = 2025041701;


### PR DESCRIPTION
### Summary of Changes

#### `classes/plugininfo.php`
- Introduced a new boolean flag `$islongtext` to determine whether a textarea should be used instead of a standard input.
- The logic checks for the presence of a `#` character in the default value field (e.g., `Activity_description=#` or `Activity_description=#Enter your text here`). 
- The above needs to be setup on the admin side when creating snippet templates. The '#' character needs to be in the Defaults field (e.g., `simple_input=HelloWorld,select=abc|def,longtext=#HelloWorld`)
- If a `#` is detected, the corresponding field is rendered as a `<textarea>` in the Mustache template.
- The `islongtext` flag is now included in the `$widget->variables[]` array.

#### `styles.css`
- Refactored styles to better support flex layouts, allowing for more responsive and consistent alignment of labels and input fields.
- Increased label width for improved readability.
- Introduced clearer separation between classes specific to `widgetoptions` elements.
- These changes have only been tested in our internal sandbox and may need further validation across other environments.

#### `templates/widgetoptions.mustache`
- Added a conditional block that checks for the `islongtext` flag.
- When true, a `<textarea>` is rendered instead of an `<input>` field for that variable.

